### PR TITLE
Allow HS256 to be specified for default tenant settings

### DIFF
--- a/app/src/pages/api/auth/[...nextauth].js
+++ b/app/src/pages/api/auth/[...nextauth].js
@@ -9,8 +9,12 @@ export const authOptions = {
             clientSecret: process.env.FUSIONAUTH_CLIENT_SECRET,
             wellKnown: `${process.env.FUSIONAUTH_URL}/.well-known/openid-configuration/${process.env.FUSIONAUTH_TENANT_ID}`,
             tenantId: process.env.FUSIONAUTH_TENANT_ID, // Only required if you're using multi-tenancy
+            client: {
+                authorization_signed_response_alg: 'HS256', // Should match Tenant or Application Setting see https://github.com/FusionAuth/fusionauth-example-nextjs-single-sign-on/issues/1
+                id_token_signed_response_alg: 'HS256'// Should match Tenant or Application Setting
+            }
         }),
-    ],
+    ]
 }
 
 export default NextAuth(authOptions)


### PR DESCRIPTION
Closes #1 

Default Tenant Settings

![image](https://github.com/FusionAuth/fusionauth-example-nextjs-single-sign-on/assets/3102249/7811c99a-aedb-465d-8e85-5a13cdf53ab1)

The FusionAuthoProvider configuration in `[...nextauth].js` can include a client setting.
```
            client: {
                authorization_signed_response_alg: 'HS256', // Should match Tenant or Application Setting see https://github.com/FusionAuth/fusionauth-example-nextjs-single-sign-on/issues/1
                id_token_signed_response_alg: 'HS256'// Should match Tenant or Application Setting
            }
```

Full File

```js
import NextAuth from "next-auth"
import FusionAuthProvider from "next-auth/providers/fusionauth"

export const authOptions = {
    providers: [
        FusionAuthProvider({
            issuer: process.env.FUSIONAUTH_ISSUER,
            clientId: process.env.FUSIONAUTH_CLIENT_ID,
            clientSecret: process.env.FUSIONAUTH_CLIENT_SECRET,
            wellKnown: `${process.env.FUSIONAUTH_URL}/.well-known/openid-configuration/${process.env.FUSIONAUTH_TENANT_ID}`,
            tenantId: process.env.FUSIONAUTH_TENANT_ID, // Only required if you're using multi-tenancy
            client: {
                authorization_signed_response_alg: 'HS256', // Should match Tenant or Application Setting see https://github.com/FusionAuth/fusionauth-example-nextjs-single-sign-on/issues/1
                id_token_signed_response_alg: 'HS256'// Should match Tenant or Application Setting
            }
        }),
    ]
}

export default NextAuth(authOptions)
```
